### PR TITLE
Don't need to fix SVGs for Chrome since version 50

### DIFF
--- a/fixsvgstack.jquery.js
+++ b/fixsvgstack.jquery.js
@@ -6,7 +6,9 @@
   // The fix is for webkit browsers only
   // [https://bugs.webkit.org/show_bug.cgi?id=91790]()
 
-  if(!(/WebKit/.test(navigator.userAgent))) {
+  if(!(/WebKit/.test(navigator.userAgent) &&
+       (!(/Chrome\/[0-9]+\./).test(navigator.userAgent) || parseInt(navigator.userAgent.match(/Chrome\/([0-9]+)\./)[1], 10) < 50)
+      )) {
     // return functions that do nothing but support chaining
     $.fn.fixSVGStack = function() { return this; };
     $.fn.fixSVGStackBackground = function() { return this; };


### PR DESCRIPTION
Not needed since version 50 according to http://caniuse.com/#search=svg%20fragment
- SVG fix will still apply to older native Android browser:
  Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G900F Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36
- Chromium also includes the equivalent Chrome version as 'Chrome/NN'
